### PR TITLE
Fix build on foxy and remove unused dependencies

### DIFF
--- a/kobuki_node/package.xml
+++ b/kobuki_node/package.xml
@@ -46,14 +46,6 @@
   <!-- ECL -->
   <build_depend>ecl_build</build_depend>
 
-  <!-- ROS -->
-  <exec_depend>diagnostic_aggregator</exec_depend>
-
-  <!-- Kobuki -->
-  <exec_depend>kobuki_ftdi</exec_depend>
-  <exec_depend>kobuki_keyop</exec_depend>
-  <exec_depend>kobuki_safety_controller</exec_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/kobuki_node/src/odometry.cpp
+++ b/kobuki_node/src/odometry.cpp
@@ -97,7 +97,7 @@ std::unique_ptr<geometry_msgs::msg::TransformStamped> Odometry::getTransform()
   odom_trans->transform.translation.z = 0.0;
   odom_trans->transform.rotation = odom_quat_;
 
-  return std::move(odom_trans);
+  return odom_trans;
 }
 
 std::unique_ptr<nav_msgs::msg::Odometry> Odometry::getOdometry()
@@ -132,7 +132,7 @@ std::unique_ptr<nav_msgs::msg::Odometry> Odometry::getOdometry()
   odom->pose.covariance[21] = 1e10; // dimensions (z, pitch and roll); this
   odom->pose.covariance[28] = 1e10; // is a requirement of robot_pose_ekf
 
-  return std::move(odom);
+  return odom;
 }
 
 } // namespace kobuki


### PR DESCRIPTION
The `std::move` call in odometry.cpp caused build error against Foxy 

```
odometry.cpp:135:19: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move] 
```

Additionally, removing `exec_depend`s that aren't used (and cause build issues right now)
* `diagnostic_aggregator` - there are not yet ros2 launchfiles in this project, therefore this isn't really a runtime dependency yet
* `kobuki_ftdi` - all of the kobuki communication is handled by the `kobuki_driver` dependency chain
* `kobuki_keyop` - the driver node should not know about teleop as a mandatory dependency (also not used anywhere yet)
* `kobuki_safety_controller` - not used anywhere