### PR TITLE
Publish the kobuki battery via BatteryState msg

### DIFF
--- a/kobuki_node/include/kobuki_node/kobuki_ros.hpp
+++ b/kobuki_node/include/kobuki_node/kobuki_ros.hpp
@@ -51,6 +51,7 @@
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/battery_state.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/empty.hpp>
@@ -122,6 +123,7 @@ private:
   rclcpp::Publisher<kobuki_ros_interfaces::msg::SensorState>::SharedPtr sensor_state_publisher_;
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_publisher_;
   rclcpp::Publisher<kobuki_ros_interfaces::msg::DockInfraRed>::SharedPtr dock_ir_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr battery_state_publisher_;
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr raw_imu_data_publisher_;
   rclcpp::Publisher<kobuki_ros_interfaces::msg::ButtonEvent>::SharedPtr button_event_publisher_;
   rclcpp::Publisher<kobuki_ros_interfaces::msg::DigitalInputEvent>::SharedPtr input_event_publisher_;
@@ -187,6 +189,7 @@ private:
   void publishRawInertia();
   void publishSensorState();
   void publishDockIRData();
+  void publishBatteryState();
   void publishVersionInfo(const kobuki::VersionInfo &version_info);
   void publishControllerInfo();
   void publishButtonEvent(const kobuki::ButtonEvent &event);

--- a/kobuki_node/src/kobuki_ros.cpp
+++ b/kobuki_node/src/kobuki_ros.cpp
@@ -686,6 +686,13 @@ void KobukiRos::publishDockIRData()
 
 void KobukiRos::publishBatteryState()
 {
+  // lazy publisher
+  if (battery_state_publisher_->get_subscription_count() == 0 &&
+      battery_state_publisher_->get_intra_process_subscription_count() == 0)
+  {
+    return;
+  }
+
   auto msg = std::make_unique<sensor_msgs::msg::BatteryState>();
   msg->header.frame_id = "base_link";
   msg->header.stamp = get_clock()->now();


### PR DESCRIPTION
I have existing infrastructure that likes to use BatteryState to generically understand robot status. It seems appropriate to publish it here. I am not sure if triggering it this frequently is necessary, but it seems fine as a start.