### PR TITLE
Make kobuki_description work in ROS 2

### DIFF
--- a/kobuki_description/CMakeLists.txt
+++ b/kobuki_description/CMakeLists.txt
@@ -1,20 +1,20 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kobuki_description)
-find_package(catkin REQUIRED COMPONENTS urdf xacro)
 
-catkin_package(
-   CATKIN_DEPENDS urdf xacro
-)
+find_package(ament_cmake REQUIRED)
 
 install(DIRECTORY launch
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+  DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY meshes
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+  DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY rviz
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+  DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY urdf
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+  DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/kobuki_description/package.xml
+++ b/kobuki_description/package.xml
@@ -1,14 +1,13 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>kobuki_description</name>
   <version>0.7.6</version>
   <description>
       Description of the Kobuki model.
-      Provides the model description of Kobuki for simulation and visualisation. The files in this 
+      Provides the model description of Kobuki for simulation and visualisation. The files in this
       package are parsed and used by a variety of other components. Most users will not interact directly
       with this package.
-      
-      WARNING: This package is disabled because it cannot be catkinized by now, as xacro dependency is not
-      catkin still. In the interim we use a unary pre-catkin stack named kobuki_description.
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author>
   <author email="marcus.liebhardt@yujinrobot.com">Marcus Liebhardt</author>
@@ -19,11 +18,15 @@
   <url type="repository">https://github.com/kobuki-base/kobuki_ros</url>
   <url type="website">http://ros.org/wiki/kobuki_description</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>urdf</build_depend>
   <build_depend>xacro</build_depend>
 
-  <run_depend>urdf</run_depend>
-  <run_depend>xacro</run_depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/kobuki_description/urdf/kobuki.urdf.xacro
+++ b/kobuki_description/urdf/kobuki.urdf.xacro
@@ -221,7 +221,7 @@
     </link>
 
     <!-- Kobuki Gazebo simulation details -->
-    <kobuki_sim/>
+    <xacro:kobuki_sim/>
 
   </xacro:macro>
 </robot>

--- a/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
@@ -146,6 +146,14 @@
 
 	  <gazebo reference="gyro_link">
 	   <sensor type="imu" name="imu">
+        <plugin name="gazebo_ros_imu_controller" filename="libgazebo_ros_imu_sensor.so">
+          <ros>
+            <argument>~/out:=imu</argument>
+          </ros>
+          <output_type>sensor_msgs/msg/Imu</output_type>
+          <body_name>gyro_link</body_name>
+          <frame_name>gyro_link</frame_name>
+        </plugin>
         <always_on>true</always_on>
         <update_rate>50</update_rate>
         <visualize>false</visualize>
@@ -170,20 +178,22 @@
 	  </gazebo>
 
 	  <gazebo>
-	    <plugin name="kobuki_controller" filename="libgazebo_ros_kobuki.so">
-	      <publish_tf>1</publish_tf>
-	      <left_wheel_joint_name>wheel_left_joint</left_wheel_joint_name>
-	      <right_wheel_joint_name>wheel_right_joint</right_wheel_joint_name>
-	      <wheel_separation>.230</wheel_separation>
-	      <wheel_diameter>0.070</wheel_diameter>
-	      <torque>1.0</torque>
-	      <velocity_command_timeout>0.6</velocity_command_timeout>
-	      <cliff_sensor_left_name>cliff_sensor_left</cliff_sensor_left_name>
-	      <cliff_sensor_center_name>cliff_sensor_front</cliff_sensor_center_name>
-	      <cliff_sensor_right_name>cliff_sensor_right</cliff_sensor_right_name>
-	      <cliff_detection_threshold>0.04</cliff_detection_threshold>
-	      <bumper_name>bumpers</bumper_name>
-        <imu_name>imu</imu_name>
+      <plugin name="differential_drive_controller" filename="libgazebo_ros_diff_drive.so">
+        <update_rate>10</update_rate>
+        <left_joint>wheel_left_joint</left_joint>
+        <right_joint>wheel_right_joint</right_joint>
+        <wheel_separation>0.230</wheel_separation>
+        <wheel_diameter>0.070</wheel_diameter>
+        <max_wheel_torque>1.0</max_wheel_torque>
+        <max_wheel_acceleration>1.0</max_wheel_acceleration>
+        <command_topic>cmd_vel</command_topic>
+        <!-- output -->
+        <publish_odom>true</publish_odom>
+        <publish_odom_tf>true</publish_odom_tf>
+        <publish_wheel_tf>true</publish_wheel_tf>
+        <odometry_topic>odom</odometry_topic>
+        <odometry_frame>odom</odometry_frame>
+        <robot_base_frame>base_link</robot_base_frame>
 	    </plugin>
 	  </gazebo>
   </xacro:macro>


### PR DESCRIPTION
* Change to ament package
* remove COLCON_IGNORE
* fix missing gazebo_ros_kobuki with off-the-shelf plugins (IMU, diff drive, odom). The other functionality that https://github.com/yujinrobot/kobuki_desktop/blob/melodic/kobuki_gazebo_plugins provided was cliff sensors and bumper, and those are already plugged in as separate sensors here