### PR TITLE
Small fixes for Rolling.

### DIFF
--- a/kobuki_node/src/kobuki_ros.cpp
+++ b/kobuki_node/src/kobuki_ros.cpp
@@ -641,7 +641,7 @@ void KobukiRos::publishRawInertia()
   kobuki::ThreeAxisGyro::Data data = kobuki_.getRawInertiaData();
 
   rclcpp::Time now = this->get_clock()->now();
-  rclcpp::Duration interval(RCL_S_TO_NS(0.01)); // Time interval between each sensor reading.
+  rclcpp::Duration interval(rclcpp::Duration::from_seconds(0.01)); // Time interval between each sensor reading.
   const double digit_to_dps = 0.00875; // digit to deg/s ratio, comes from datasheet of 3d gyro[L3G4200D].
   unsigned int length = data.followed_data_length / 3;
   for (unsigned int i = 0; i < length; i++) {

--- a/kobuki_node/src/odometry.cpp
+++ b/kobuki_node/src/odometry.cpp
@@ -45,7 +45,7 @@ Odometry::Odometry(
 ):
   pose_(ecl::linear_algebra::Vector3d::Zero()),  // identity
   pose_update_rates_(ecl::linear_algebra::Vector3d::Zero()),  // identity
-  cmd_vel_timeout_(RCL_S_TO_NS(cmd_vel_timeout_sec)),
+  cmd_vel_timeout_(rclcpp::Duration::from_seconds(cmd_vel_timeout_sec)),
   odom_frame_(odom_frame),
   base_frame_(base_frame),
   publish_tf_(publish_tf),

--- a/kobuki_safety_controller/src/safety_controller.cpp
+++ b/kobuki_safety_controller/src/safety_controller.cpp
@@ -300,13 +300,13 @@ void SafetyController::spin()
     else
     {
       double time_to_extend_bump_cliff_events = this->get_parameter("time_to_extend_bump_cliff_events").get_value<double>();
-      rclcpp::Duration extend_bump_cliff_events_duration = rclcpp::Duration(time_to_extend_bump_cliff_events);
+      rclcpp::Duration extend_bump_cliff_events_duration = rclcpp::Duration::from_seconds(time_to_extend_bump_cliff_events);
       // if we want to extend the safety state and we're within the time, just keep sending msg_
       // TODO(clalancette): this is buggy in the case that time_to_extend_bump_cliff_events
       // is set to something > 0.  The very first time through this loop, we could end up
       // publishing an empty msg_ for no reason, since last_event_time ~= this->get_clock()->now().
       // Need to think about how to improve this.
-      if (extend_bump_cliff_events_duration > rclcpp::Duration(1e-10) &&
+      if (extend_bump_cliff_events_duration > rclcpp::Duration::from_seconds(1e-10) &&
           this->get_clock()->now() - last_event_time_ < extend_bump_cliff_events_duration)
       {
         velocity_command_publisher_->publish(*msg_);


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@stonier These fixes get rid of warnings while building against Rolling.  They *only* apply to Rolling; we can't release them into Galactic or Foxy.  I'm not sure how we should handle this in this repositories branching scheme.