### PR TITLE
Switch to parameter events for parameter changes

### DIFF
--- a/kobuki_bumper2pc/include/kobuki_bumper2pc/kobuki_bumper2pc.hpp
+++ b/kobuki_bumper2pc/include/kobuki_bumper2pc/kobuki_bumper2pc.hpp
@@ -48,9 +48,8 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
-#include <rcl_interfaces/msg/set_parameters_result.hpp>
+#include <rcl_interfaces/msg/parameter_event.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
@@ -95,9 +94,11 @@ private:
 
   sensor_msgs::msg::PointCloud2 pointcloud_;
 
-  OnSetParametersCallbackHandle::SharedPtr param_change_handle_;
+  std::shared_ptr<rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent,
+    std::allocator<void>>> parameter_subscription_;
 
-  rcl_interfaces::msg::SetParametersResult paramChangeCallback(const std::vector<rclcpp::Parameter> & parameters);
+  void onParameterEvent(
+    std::shared_ptr<rcl_interfaces::msg::ParameterEvent> event);
 
   void reconfigurePointCloud(float radius, float height, float angle, const std::string & base_link_frame);
 

--- a/kobuki_safety_controller/CMakeLists.txt
+++ b/kobuki_safety_controller/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(ecl_build REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(kobuki_ros_interfaces REQUIRED)
-find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -18,7 +17,6 @@ include_directories(include)
 add_library(kobuki_safety_controller SHARED src/safety_controller.cpp)
 ament_target_dependencies(kobuki_safety_controller
   "geometry_msgs"
-  "rcl_interfaces"
   "kobuki_ros_interfaces"
   "rclcpp"
   "rclcpp_components"

--- a/kobuki_safety_controller/include/kobuki_safety_controller/safety_controller.hpp
+++ b/kobuki_safety_controller/include/kobuki_safety_controller/safety_controller.hpp
@@ -50,7 +50,6 @@
 *****************************************************************************/
 
 #include <memory>
-#include <vector>
 
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -95,10 +94,8 @@ private:
   bool wheel_left_dropped_, wheel_right_dropped_;
   bool bumper_left_pressed_, bumper_center_pressed_, bumper_right_pressed_;
   bool cliff_left_detected_, cliff_center_detected_, cliff_right_detected_;
-  rclcpp::Duration time_to_extend_bump_cliff_events_;
   rclcpp::Time last_event_time_;
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
 
   std::unique_ptr<geometry_msgs::msg::Twist> msg_; // velocity command
 
@@ -152,9 +149,6 @@ private:
    * @param msg incoming topic message
    */
   void resetSafetyStatesCB(const std_msgs::msg::Empty::SharedPtr msg);
-
-rcl_interfaces::msg::SetParametersResult parameterUpdate(
-  const std::vector<rclcpp::Parameter> & parameters);
 };
 
 

--- a/kobuki_safety_controller/package.xml
+++ b/kobuki_safety_controller/package.xml
@@ -24,14 +24,12 @@
   <build_depend>ecl_build</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kobuki_ros_interfaces</build_depend>
-  <build_depend>rcl_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>kobuki_ros_interfaces</exec_depend>
-  <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>std_msgs</exec_depend>


### PR DESCRIPTION
It turns out that we should *not* be using parameter change callbacks to update internal variables.  That's because parameter change callbacks are really meant to reject parameters that are out-of-bounds, and they can be chained.  That means that if a later callback in the chain were to reject the change, the parameter database would not have the update, but we would have updated internal state based on it.  That leads to an inconsistent system.

Instead, use the parameter events interface to look at changes to the parameters.  This is called *after* all of the parameter change callbacks have happened, so we know for sure that this update has taken place.