### PR TITLE
Remove unnecessary setvbuf from nodes.

### DIFF
--- a/kobuki_keyop/src/keyop_node.cpp
+++ b/kobuki_keyop/src/keyop_node.cpp
@@ -27,7 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cstdio>
 #include <memory>
 
 #include <rclcpp/rclcpp.hpp>
@@ -36,9 +35,6 @@
 
 int main(int argc, char** argv)
 {
-  // Configures stdout stream for no buffering
-  setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
-
   rclcpp::init(argc, argv);
 
   rclcpp::spin(std::make_shared<kobuki_keyop::KeyOp>(rclcpp::NodeOptions()));

--- a/kobuki_node/src/kobuki_ros_node.cpp
+++ b/kobuki_node/src/kobuki_ros_node.cpp
@@ -1,4 +1,3 @@
-#include <cstdio>
 #include <memory>
 
 #include <rclcpp/rclcpp.hpp>
@@ -7,9 +6,6 @@
 
 int main(int argc, char** argv)
 {
-  // Configures stdout stream for no buffering
-  setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
-
   rclcpp::init(argc, argv);
 
   rclcpp::spin(std::make_shared<kobuki_node::KobukiRos>(rclcpp::NodeOptions()));

--- a/kobuki_safety_controller/src/safety_controller_node.cpp
+++ b/kobuki_safety_controller/src/safety_controller_node.cpp
@@ -27,7 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cstdio>
 #include <memory>
 
 #include <rclcpp/rclcpp.hpp>
@@ -36,9 +35,6 @@
 
 int main(int argc, char** argv)
 {
-  // Configures stdout stream for no buffering
-  setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
-
   rclcpp::init(argc, argv);
 
   rclcpp::spin(std::make_shared<kobuki_safety_controller::SafetyController>(rclcpp::NodeOptions()));


### PR DESCRIPTION
This hasn't been necessary since Eloquent, so just remove
the unnecessary code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>