### PR TITLE
Remove unnecessary parameter callback from keyop.

### DIFF
--- a/kobuki_keyop/CMakeLists.txt
+++ b/kobuki_keyop/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(ecl_build REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(kobuki_ros_interfaces REQUIRED)
-find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 
@@ -18,7 +17,6 @@ add_library(kobuki_keyop SHARED src/keyop.cpp)
 ament_target_dependencies(kobuki_keyop
   "geometry_msgs"
   "kobuki_ros_interfaces"
-  "rcl_interfaces"
   "rclcpp"
   "rclcpp_components"
 )

--- a/kobuki_keyop/include/kobuki_keyop/keyop.hpp
+++ b/kobuki_keyop/include/kobuki_keyop/keyop.hpp
@@ -53,7 +53,6 @@
 #include <vector>
 
 #include <geometry_msgs/msg/twist.hpp>  // for velocity commands
-#include <rcl_interfaces/msg/set_parameters_result.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <kobuki_ros_interfaces/msg/keyboard_input.hpp> // keycodes from remote teleops.
@@ -96,11 +95,7 @@ private:
   // dealing with keyboard strokes and remote keyboard strokes
   std::mutex cmd_mutex_;
   std::shared_ptr<geometry_msgs::msg::Twist> cmd_;
-  double linear_vel_step_, linear_vel_max_;
-  double angular_vel_step_, angular_vel_max_;
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
-  rcl_interfaces::msg::SetParametersResult parameterUpdate(const std::vector<rclcpp::Parameter> & parameters);
 
   /*********************
    ** Runtime

--- a/kobuki_keyop/package.xml
+++ b/kobuki_keyop/package.xml
@@ -15,7 +15,6 @@
 
   <!-- Ros -->
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>rcl_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
 
@@ -28,7 +27,6 @@
 
   <!-- Ros -->
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
 


### PR DESCRIPTION
We can just fetch the data out of the database as needed,
saving us a bunch of code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>