### PR TITLE
Make random_walker depend on rclcpp_components.

### DIFF
--- a/kobuki_random_walker/CMakeLists.txt
+++ b/kobuki_random_walker/CMakeLists.txt
@@ -27,6 +27,7 @@ ament_target_dependencies(kobuki_random_walker
   "geometry_msgs"
   "kobuki_ros_interfaces"
   "rclcpp"
+  "rclcpp_components"
   "std_msgs"
 )
 


### PR DESCRIPTION
Otherwise it may fail to compile in some situations.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>