### PR TITLE
Fix a warning about a deprecated tf2 header.

### DIFF
--- a/kobuki_auto_docking/include/kobuki_auto_docking/auto_docking_ros.hpp
+++ b/kobuki_auto_docking/include/kobuki_auto_docking/auto_docking_ros.hpp
@@ -39,7 +39,7 @@
 
 #include <kobuki_core/dock_drive.hpp>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace kobuki_auto_docking
 {


### PR DESCRIPTION
This *only* applies to Rolling, so we'll need a new Galactic
release before applying this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This fix does not apply to Galactic, only to Rolling.  Therefore, before putting this in I'm going to make a new `release/1.2.x` branch for Galactic.