### PR TITLE
Renaming velocity_smoother dependency

### DIFF
--- a/kobuki_keyop/package.xml
+++ b/kobuki_keyop/package.xml
@@ -33,7 +33,7 @@
   <!-- Kobuki -->
   <exec_depend>cmd_vel_mux</exec_depend>
   <exec_depend>kobuki_ros_interfaces</exec_depend>
-  <exec_depend>velocity_smoother</exec_depend>
+  <exec_depend>kobuki_velocity_smoother</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
`velocity_smother` dependency [was renamed](https://github.com/kobuki-base/kobuki_velocity_smoother/pull/20) to  `kobuki_velocity_smother`, changing the dependency reference in the `package.xml` of `kobuki_keyop`.