### PR TITLE
canceling the goal without crashing the node

### DIFF
--- a/kobuki_auto_docking/src/auto_docking_ros.cpp
+++ b/kobuki_auto_docking/src/auto_docking_ros.cpp
@@ -103,18 +103,11 @@ rclcpp_action::CancelResponse AutoDockingROS::handle_cancel(
 {
   (void)goal_handle;
 
-  // (Bug) The program crashed after terminating (Ctrl+C) the activate.sh
-  // info: terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
   RCLCPP_INFO(this->get_logger(), "Received request to cancel goal");
 
   if (dock_.isEnabled()) {
     dock_.disable();
   }
-
-  auto result_ = std::make_shared<AutoDocking::Result>();
-  result_->text = "Cancelled: Cancel requested.";
-  goal_handle->canceled(result_);
-  RCLCPP_INFO(this->get_logger(), "Result: %s", result_->text.c_str());
 
   return rclcpp_action::CancelResponse::ACCEPT;
 }


### PR DESCRIPTION
When canceling the auto docking goal in the terminal (CTRL-C) or in software using the ClientGoalHandle, the AutoDocking action server crashes. When removing the following lines of code, the goal is successfully canceled and the action server keeps running.