### PR TITLE
Change robot_base_frame in kobuki_gazebo.urdf.xacro file.

### DIFF
--- a/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
@@ -193,7 +193,7 @@
         <publish_wheel_tf>true</publish_wheel_tf>
         <odometry_topic>odom</odometry_topic>
         <odometry_frame>odom</odometry_frame>
-        <robot_base_frame>base_link</robot_base_frame>
+        <robot_base_frame>base_footprint</robot_base_frame>
 	    </plugin>
 	  </gazebo>
   </xacro:macro>


### PR DESCRIPTION
Before the fix, the tf tree should look like `base_footprint` -> `base_link` -> ...
When simulating Kobuki using Gazebo, the plugin would publish: `odom` -> `base_link`
This caused an error in the transform from `base_footprint` to `base_link` since one link could only have one parent.

To prevent the Gazebo plugin (diff-drive) from publishing `odom` -> `base_link`, we should modify the configuration in the URDF.

> If you ever encounter points of confusion or have any questions, please feel free to discuss them with me. :smile: 