### PR TITLE
[kobuki_ros] Fix pessimizing-move error by removing std::move()

### DIFF
--- a/kobuki_node/src/kobuki_ros.cpp
+++ b/kobuki_node/src/kobuki_ros.cpp
@@ -595,7 +595,7 @@ void KobukiRos::publishWheelState()
   if (odom_update != nullptr) {
     odom_broadcaster_->sendTransform(*odom_update);
   }
-  odom_publisher_->publish(std::move(odometry_->getOdometry()));
+  odom_publisher_->publish(odometry_->getOdometry());
 
   joint_states_.header.stamp = this->get_clock()->now();
   joint_state_publisher_->publish(joint_states_);


### PR DESCRIPTION
Building in the ROS Jazzy docker container gives the following error:

```
src/kobuki_ros/kobuki_node/src/kobuki_ros.cpp: In member function ‘void kobuki_node::KobukiRos::publishWheelState()’:
src/kobuki_ros/kobuki_node/src/kobuki_ros.cpp:597:37: error: moving a temporary object prevents copy elision [-Werror=pessimizing-move]
   597 |   }
       |                                     ^                         
src/kobuki_ros/kobuki_node/src/kobuki_ros.cpp:597:37: note: remove ‘std::move’ call
cc1plus: all warnings being treated as errors
```

This PR removes the `std::move()` .

I built and tested docker containers for Humble, Iron, and Jazzy after this fix, and in all cases the Kobuki is able to be controlled via teleop_twist_keyboard. I'll post a link to the dockerfile I use when I finish cleaning up all the temporary comments.