### PR TITLE
Fixed battery percentage scale

### DIFF
--- a/kobuki_node/src/kobuki_ros.cpp
+++ b/kobuki_node/src/kobuki_ros.cpp
@@ -718,7 +718,7 @@ void KobukiRos::publishBatteryState()
   msg->power_supply_technology = sensor_msgs::msg::BatteryState::POWER_SUPPLY_TECHNOLOGY_LION;
   msg->location = "";
   msg->serial_number = "";
-  msg->percentage = battery.percent();
+  msg->percentage = battery.percent() * 0.01f;
   msg->present = true;
   battery_state_publisher_->publish(std::move(msg));
 }


### PR DESCRIPTION
BatteryState message clearly says it is 0-1. (see https://docs.ros.org/en/kilted/p/sensor_msgs/msg/BatteryState.html ).

Kobuki_core produces values between 0 and 100: https://github.com/kobuki-base/kobuki_core/blob/3e0652dc4006d8345a86298ac05d82049747bc7f/src/driver/battery.cpp#L70-L71 .